### PR TITLE
camera and microphone enabled in Safari 11

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -333,10 +333,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1002,10 +1002,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
- [ ] Summarize your changes:
Camera and Microphone are enabled as Feature-Policy in Safari 11
- [ ] Data: 
https://webkit.org/blog/8060/release-notes-for-safari-technology-preview-47/
https://webkit.org/blog/8216/new-webkit-features-in-safari-11-1/
https://trac.webkit.org/changeset/225963/webkit
- [ ] Data:
Tested with a sample app
- [ ] Link to related issues or pull requests, if any
